### PR TITLE
check command `type` is not valid

### DIFF
--- a/generator.sh
+++ b/generator.sh
@@ -86,7 +86,7 @@ do
     if [ "$shell" = "fish" ]; then
         ifCond="if type lolcat > /dev/null"
     else
-        ifCond='if [ "type lolcat" ]; then'
+        ifCond='if [[ `type lolcat` != *"not found" ]]; then'
     fi
 
     cat << LOLCAT >> "$newDist"


### PR DESCRIPTION
原来的逻辑校验`lolcat`命令不严谨，当命令不存在时，仍然可以执行`echo "$@" | lolcat`

---

``` bash
if [ "type lolcat" ]; then
```
