### PR TITLE
Update Travis CI Ubuntu env from 16.04 to 22.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: minimal
-dist: xenial
+dist: jammy
 
 git:
   depth: 5


### PR DESCRIPTION
Though Ubuntu Xenial is still the default Ubuntu version on Travis CI right now(it's actually now, when I first manually set it here), it's EOL and old enough, let's see if everything goes well with Ubuntu 22.04 (Jammy Jellyfish)!

Reference:
- https://docs.travis-ci.com/user/reference/linux/