### PR TITLE
Remove TravisBuddy integration as it's deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,11 +146,3 @@ jobs:
       - type fish && fish --version
     script:
       - ./test-scripts/fish
-
-notifications:
-  webhooks:
-    urls:
-      - https://www.travisbuddy.com/
-    on_success: never
-    on_cancel: never
-    on_start: never


### PR DESCRIPTION
The project has been archived and is read-only now

Reference: https://github.com/bluzi/travis-buddy