### PR TITLE
Simplify Travis CI macOS homebrew package install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,8 +101,11 @@ jobs:
     osx_image: xcode13.1
     env:
       - task=test-dist-zsh
+    addons:
+      homebrew:
+        packages:
+          - zsh
     before_script:
-      - brew update && brew install zsh
       - type zsh && zsh --version
     script:
       - ./test-scripts/zsh
@@ -111,8 +114,11 @@ jobs:
     osx_image: xcode13.1
     env:
       - task=test-dist-ksh
+    addons:
+      homebrew:
+        packages:
+          - ksh
     before_script:
-      - brew update && brew install ksh
       - type ksh && ksh --version || printf ""
     script:
       - ./test-scripts/ksh
@@ -130,8 +136,11 @@ jobs:
     osx_image: xcode13.1
     env:
       - task=test-dist-bash-brew-install
+    addons:
+      homebrew:
+        packages:
+          - bash
     before_script:
-      - brew update && brew install bash
       - export PATH="/usr/local/bin:$PATH"
       - type bash && bash --version
     script:
@@ -141,8 +150,11 @@ jobs:
     osx_image: xcode13.1
     env:
       - task=test-dist-fish
+    addons:
+      homebrew:
+        packages:
+          - fish
     before_script:
-      - brew update && brew install fish
       - type fish && fish --version
     script:
       - ./test-scripts/fish


### PR DESCRIPTION
Use Travis CI Homebrew addon to install packages, instead of manually install them via shell commands.

According to the latest Travis CI "The macOS Build Environment" and "Installing Dependencies" documentation:

> The Travis Homebrew addon is the simplest, fastest and most reliable
> way to install dependencies.

> By default, the Homebrew addon will not run `brew update` before
> installing packages. `brew update` can take a long time and slow down
> your builds. If you need more up-to-date versions of packages than the
> snapshot on the build VM has, you can add `update: true` to the addon
> configuration:

As Travis CI looks very confident about it, the original `brew update` corresponding `update: true` in the addon is not enabled, unless some issues were found without the update, hopefully can speed up the tests.

Reference:
- https://docs.travis-ci.com/user/reference/osx/#homebrew
- https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos